### PR TITLE
Fix state parsing error

### DIFF
--- a/components/server/experience_list.tsx
+++ b/components/server/experience_list.tsx
@@ -37,9 +37,11 @@ function fmt_location(city: string, state: string) {
 
     case "California":
       abbreviatedState = "CA";
+      break;
 
     case "Illinois":
       abbreviatedState = "IL";
+      break;
 
     default:
       break;


### PR DESCRIPTION
State data from the backend service is converted from a full format (e.g. California) to an abbreviated form for display on the website. The case statement which implemented this conversion was erroneously missing `break` statements, causing experiences from "California" to be represented by the abbreviation for Illinois (IL). This change was fixed by adding back those missing `break` statements.